### PR TITLE
Dakota/loader fixes

### DIFF
--- a/components/LoadingSpinner/editor.scss
+++ b/components/LoadingSpinner/editor.scss
@@ -5,14 +5,15 @@
 	display: flex;
 	justify-content: center;
 	padding: 1em;
+	width: max-content;
 
 
-	.bu-components-loading-spinner-label {
+	.bu-components-loading-spinner--label {
 		font-weight: bold;
 		margin-right: 1ch;
 	}
 
-	&.has-shadow {
+	&.bu-components-loading-spinner--has-shadow {
 		box-shadow:
 		3.4px 4.7px 2.7px rgba(0, 0, 0, 0.043),
 		8.7px 11.8px 6.9px rgba(0, 0, 0, 0.062),

--- a/components/LoadingSpinner/index.mjs
+++ b/components/LoadingSpinner/index.mjs
@@ -23,8 +23,8 @@ import './editor.scss';
 const getClasses = ( className, text, shadow ) => classnames(
 	'bu-components-loading-spinner',
 	{
-		[ `has-shadow` ]: shadow,
-		[ `has-text` ]: text,
+		[ `bu-components-loading-spinner--has-shadow` ]: shadow,
+		[ `bu-components-loading-spinner--has-text` ]: text,
 		[ className ]: className,
 	}
 );
@@ -39,7 +39,7 @@ export const LoadingSpinner = ( props ) => {
 	return (
 		<div className={ getClasses( className, text, shadow ) }>
 			{ text && (
-				<strong className="bu-components-loading-spinner-label">{ text }</strong>
+				<strong className="bu-components-loading-spinner--label">{ text }</strong>
 			)}
 				<Spinner />
 		</div>


### PR DESCRIPTION
- Make class names for states in the component more specific so we don't end up with conflicts with themes in the editor. 
- Add width: max-content; style to component so it doesn't span the full width of the editor. 

![Screenshot 2025-04-03 at 11 31 09 AM](https://github.com/user-attachments/assets/b7269b2d-2073-410b-92d0-9615adbb4b7d)
