### PR TITLE
Changes block-imports reference

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -29,7 +29,8 @@
 		"@wordpress/scripts": "^27.8.0"
 	},
 	"dependencies": {
-		"@bostonuniversity/block-imports": "file:../index.js",
-		"@wordpress/icons": "^9.48.0"
+		"@bostonuniversity/block-imports": "file:..",
+		"@wordpress/icons": "^9.48.0",
+		"classnames": "^2.5.1"
 	}
 }


### PR DESCRIPTION
The development environment was failing to properly resolve dependencies (specifically classnames and lodash) because the local package reference in `package.json` is pointing to an `index.js` file instead of the package directory:

Changing the package reference to point to the parent directory ensures that npm can properly resolve all dependencies from the main package into the development environment. The fix allows the Gutenberg blocks to load correctly by making the package's dependencies available to the development environment.

Also, it appears that webpack needs the `classnames` package to be installed in the root package.json in order to compile it into the development bundle.