### PR TITLE
another example that works

### DIFF
--- a/dev/src/blocks/urd-post-via-term/edit.js
+++ b/dev/src/blocks/urd-post-via-term/edit.js
@@ -45,27 +45,44 @@ export default function Edit( props ) {
 	const { termSlug } = attributes;
 
 	let termID = '';
+	let termEntity = undefined;
+	let termTax = undefined;
+	let termQuery = undefined;
+	let requestEntity = undefined;
+	let postType = undefined;
+	let postQuery = undefined;
+
+	if ( termSlug ) {
+		termEntity = 'taxonomy';
+		termTax = 'fish';
+		termQuery = {
+			slug: termSlug
+		};
+	}
 
 	const [ termData, termIsLoading, termInvalidateRequest ] = useRequestData(
-		'taxonomy',
-		'fish',
-		{
-			slug: termSlug
-		}
+		termEntity,
+		termTax,
+		termQuery
 	);
 
-	if (termData && termData.length > 0) {
+	if (termSlug && termData && termData.length > 0) {
 		console.log('Term Data: ', termData);
 		termID = termData[0].id;
+		requestEntity = 'postType';
+		postQuery = {
+			fish: termID
+		}
+		postType = 'import-bob';
 	}
 
 	const [ data, isLoading, invalidateRequest ] = useRequestData(
-		'postType',
-		'import-bob',
-		{
-			fish: [termID]
-		}
+		requestEntity,
+		postType,
+		postQuery
 	);
+
+	console.log("posts:", data );
 
 	return (
 		<>
@@ -94,15 +111,14 @@ export default function Edit( props ) {
 				{/*	)}*/}
 
 				<h2>Hi. We'll have more in a bit.</h2>
-				{/*{data && data.length > 0 && (*/}
-				{/*	data.map((post) => {*/}
-				{/*		return (*/}
-				{/*			<ThePost*/}
-				{/*				post={post}*/}
-				{/*			/>*/}
-				{/*		)*/}
-				{/*	})*/}
-				{/*)}*/}
+				{data && data.length > 0 && (
+					data.map((post) => {
+						return (
+							<ThePost post={post} />
+						)
+					})
+				)}
+
 
 				{ ! termSlug && (
 					<strong>Enter a Fish slug in the inspector controls</strong>

--- a/hooks/useRequestData/index.mjs
+++ b/hooks/useRequestData/index.mjs
@@ -18,7 +18,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * @param {object | number} [query] Optional. Query to pass to the geEntityRecords request. Defaults to an empty object. If a number is passed, it is used as the ID of the entity to retrieve via getEntityRecord.
  * @returns {Array} The data returned from the request.
  */
-export const useRequestData = (entity='postType', kind='post', query = {} ) => {
+export const useRequestData = (entity, kind, query = {} ) => {
 	const whichGER = isObject(query) ? 'getEntityRecords' : 'getEntityRecord';
 	const { invalidateResolution } = useDispatch('core/data');
 	const { data, isLoading } = useSelect(


### PR DESCRIPTION
Here is another example that I found that works based on some comments and reading about dependency arrays that some hooks support. 

useSelect() has a dependency array and the useRequestData hook from 10up specified that `entity`, `kind` and `query` were dependencies. I think the earlier change that sets default values for `entity` and `kind` cause the hook to fire even if we don't pass a value into the useRequestData() hook because it's being given a fall back value. So I saw in my sandbox if I set a variable as undefined for something like `termEntity` it was still firing a request but falling back to the default postType value for entity in the hook. I removed this as a test. 

In this experiment instead of turning everything into components I just used a bunch of undefined let variables to try to leverage the dependency array of the underlying useSelect hook inside useRequestData. This example also appears to work in my local sandbox and gets back the posts without throwing the errors @hirozed was seeing yesterday. 