### PR TITLE
Dakota/gut 175 post picker sidebar cleanup

### DIFF
--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -1,11 +1,8 @@
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { TextControl, Button, Spinner, Modal,
-	__experimentalRadio as Radio,
-	__experimentalRadioGroup as RadioGroup,
-	Flex,
-	FlexItem,
-	FlexBlock,
+import {
+	Spinner,
+	Modal,
 } from '@wordpress/components';
 import { useEffect } from 'react';
 
@@ -22,9 +19,9 @@ import './editor.scss';
 
 export const PostChooserModal = ( props ) => {
 	const {
-		onClose,
+		onClose = () => {}, // Function to call when the modal is closed.
 		label,
-		onSelectPost,
+		onSelectPost = () => {}, // Function to call when a post is selected.
 		postTypes,
 		placeholder = __( 'Enter a search term…' ),
 		title = __( 'Choose a Post' ),

--- a/components/PostChooser/editor.scss
+++ b/components/PostChooser/editor.scss
@@ -1,12 +1,31 @@
 // General Editor styles for the PostChooser component
 
 
+/**
+* The following styles are used to style the
+* PostChooserSidebar component.
+*/
+.components-post-chooser-sidebar-posttitle {
+	font-size: 1em;
+	display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+	margin-block: 0.5em;
+}
 
+.components-post-chooser-sidebar-posttitle-label {
+	font-size: 0.8em;
+	display: block;
+	margin-bottom: 0.5em;
+}
 
+.components-post-chooser-sidebar-posttitle-link {
+	font-size: 0.8em;
+}
 
-
-
-
-
+.components-post-chooser-sidebar-posttitle-heading {
+	margin-block: 0;
+}
 
 

--- a/components/PostChooser/postchooser.js
+++ b/components/PostChooser/postchooser.js
@@ -22,7 +22,7 @@ export const PostChooser = ( props ) => {
 		postTypes = [ 'posts', 'pages' ], // Default post types to search.
 		searchPlaceholder,
 		minCharacters = 3,
-		onClose = () => {},
+		onClose,
 	} = props;
 
 	return (

--- a/components/PostChooser/postchooser.js
+++ b/components/PostChooser/postchooser.js
@@ -7,8 +7,6 @@
 
 // WordPress dependencies
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
 
 // Internal dependencies
 import { PostChooserModal } from './editor-partials/modal/index.js';
@@ -21,42 +19,21 @@ export const PostChooser = ( props ) => {
 		onSelectPost,
 		modalLabel,
 		modalTitle,
-		buttonLabel = __( 'Select Post' ),
 		postTypes = [ 'posts', 'pages' ], // Default post types to search.
 		searchPlaceholder,
 		minCharacters = 3,
+		onClose = () => {},
 	} = props;
 
-	/**
-	 * Modal State Handlers.
-	 *
-	 * Manages the open/closed state of the Modal
-	 * that contains the Post Chooser UI.
-	 */
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
-
 	return (
-		<>
-			<Button
-				isPrimary
-				className="bu-components-post-chooser-button"
-				onClick={ () => {
-					setIsModalOpen( true );
-				} }
-			>
-				{ buttonLabel }
-			</Button>
-			{ isModalOpen && (
-				<PostChooserModal
-					onSelectPost={ onSelectPost }
-					label={ modalLabel }
-					title={ modalTitle }
-					postTypes={ postTypes }
-					placeholder={ searchPlaceholder }
-					minCharacters={ minCharacters }
-					onClose={ () => setIsModalOpen( false ) }
-				/>
-			) }
-		</>
+		<PostChooserModal
+			onSelectPost={ onSelectPost }
+			label={ modalLabel }
+			title={ modalTitle }
+			postTypes={ postTypes }
+			placeholder={ searchPlaceholder }
+			minCharacters={ minCharacters }
+			onClose={ onClose }
+		/>
 	);
 };

--- a/components/PostChooser/postchoosersidebar.js
+++ b/components/PostChooser/postchoosersidebar.js
@@ -7,8 +7,6 @@
 // WordPress dependencies.
 import { __ } from '@wordpress/i18n';
 
-import { Fragment } from '@wordpress/element';
-
 import {
 	Button,
 	PanelBody,
@@ -20,72 +18,84 @@ import {
 } from '@wordpress/components';
 
 import { InspectorControls } from '@wordpress/block-editor';
-
 import { decodeEntities } from '@wordpress/html-entities';
+
+// Import Editor Styles for this Component.
+import './editor.scss';
 
 export const PostChooserSidebar = function ( props ) {
 	const {
-		children,
-		postID,
-		postTitle,
-		postURL,
-		selectHandler,
-		onRemovePost,
+		children, // Optional. Allows child elements to be passed into the component.
+		postID, // The ID of the selected post.
+		postTitle, // The title of the selected post.
+		postURL, // The URL of the selected post.
+		onRemovePost = () => {}, // Function to call when the post is removed.
+		removePostButtonLabel = __( 'Remove' ), // Label for the remove post button.
+		openButtonLabel = __( 'Select Post' ), // Label for the open post chooser button.
+		changeButtonLabel = __( 'Change' ), // Label for the change post button.
+		panelTitle = __( 'Selected Post' ), // Title for the sidebar panel.
+		showPostLink = true, // Whether to show a link to the post.
+		onOpenPostChooserModal = () => {}, // Function to call when the open modal button is pressed.
 	} = props;
 
-	const onhandleRemovePost = ( e ) => {
-		// Let the block code take care of further handling.
-		// Call passed onSelectPost Function.
-		if ( onRemovePost instanceof Function ) {
-			onRemovePost( e );
-		}
-	};
-
 	return (
-		<>
-			<InspectorControls>
-				<PanelBody
-					title={ __( 'Selected Post' ) }
-					className="bu-components-post-chooser-sidebar-options"
-				>
-					<>
-						<PanelRow>
-							{ postTitle && (
-								<>
-									<h2>
-										Title: { decodeEntities( postTitle ) }
-									</h2>
-									{ postURL && (
-										<p>
-											<ExternalLink href={ postURL }>
-												View Post
-											</ExternalLink>
-										</p>
-									) }
-								</>
+		<InspectorControls>
+			<PanelBody
+				title={ panelTitle }
+				className="bu-components-post-chooser-sidebar-options"
+			>
+				{ postTitle && (
+					<PanelRow>
+						<div className="components-post-chooser-sidebar-posttitle">
+							<span className="components-post-chooser-sidebar-posttitle-label">Title:</span>
+							{ postURL && showPostLink && (
+								<ExternalLink href={ postURL } className="components-post-chooser-sidebar-posttitle-link">
+									View Post
+								</ExternalLink>
 							) }
-						</PanelRow>
-						<PanelRow>
-							<Flex wrap={ true }>
-								<FlexItem>{ children }</FlexItem>
-								{ postID && (
-									<FlexBlock>
-										<Button
-											//variant="tertiary"
-											isLink
-											onClick={ ( e ) => {
-												onhandleRemovePost( e );
-											} }
-										>
-											Remove
-										</Button>
-									</FlexBlock>
-								) }
-							</Flex>
-						</PanelRow>
-					</>
-				</PanelBody>
-			</InspectorControls>
-		</>
+							<h2 className="components-post-chooser-sidebar-posttitle-heading">
+								{ decodeEntities( postTitle ) }
+							</h2>
+						</div>
+					</PanelRow>
+				) }
+				<PanelRow>
+					<Flex wrap={ true }>
+						<FlexItem>
+							<Button
+								isPrimary
+								onClick={ () => onOpenPostChooserModal() }
+							>
+								{ postID ? changeButtonLabel : openButtonLabel }
+							</Button>
+						</FlexItem>
+						{ postID && (
+							<FlexBlock>
+								<Button
+									isLink
+									onClick={ onRemovePost }
+								>
+									{ removePostButtonLabel }
+								</Button>
+							</FlexBlock>
+						) }
+					</Flex>
+				</PanelRow>
+				{
+				/*
+				* Optional. If children are passed, render them in the sidebar.
+				* This allows for additional controls or information to be displayed. This
+				* is useful for custom controls or displaying info related to the post.
+				* Example usage: <PostChooserSidebar>{ <CustomControl /> }</PostChooserSidebar>
+				*/ }
+				{ children && (
+					<PanelRow>
+						<div className="components-post-chooser-sidebar-children">
+							{ children }
+						</div>
+					</PanelRow>
+				) }
+			</PanelBody>
+		</InspectorControls>
 	);
 };

--- a/dev/src/blocks/post-chooser/edit.js
+++ b/dev/src/blocks/post-chooser/edit.js
@@ -145,7 +145,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 
 				{ ! selectedPostID && (
 					<>
-						<p>Post picker block, no post selected. <a href="#" onClick={ setIsPostChooserModalOpen }>Select Post</a></p>
+						<p>Post picker block, no post selected. <a href="#" onClick={ () => setIsPostChooserModalOpen( true ) }>Select Post</a></p>
 
 						{ isSelected && (
 							<Button

--- a/dev/src/blocks/post-chooser/edit.js
+++ b/dev/src/blocks/post-chooser/edit.js
@@ -13,7 +13,6 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	useBlockProps,
-	InspectorControls,
 	MediaUpload,
 	MediaUploadCheck,
 } from '@wordpress/block-editor';
@@ -22,15 +21,11 @@ import { decodeEntities } from '@wordpress/html-entities';
 
 import {
 	Button,
-	PanelBody,
-	ToggleControl,
-	TextControl,
-	SelectControl,
-	ExternalLink,
 } from '@wordpress/components';
 
+import { useState } from '@wordpress/element';
+
 import {
-	useRequestData,
 	useMedia,
 	LoadingSpinner,
 	PostChooser,
@@ -68,6 +63,14 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 		focalPoint,
 	} = attributes;
 
+	/**
+	 * Post Chooser Modal State Handlers.
+	 *
+	 * Manages the open/closed state of the Modal
+	 * that contains the Post Chooser UI.
+	 */
+	const [ isPostChooserModalOpen, setIsPostChooserModalOpen ] = useState( false );
+
 	const onChangeTitle = ( newTitle ) => {
 		setAttributes( { title: newTitle } );
 	};
@@ -98,6 +101,9 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 			selectedPostURL: post.link,
 			selectedPostIMG: post.featured_media,
 		} );
+
+		// Close the modal after selecting a post
+		setIsPostChooserModalOpen( false );
 	};
 
 	function handleFocalPointChange( value ) {
@@ -123,21 +129,47 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 
 	return (
 		<div { ...useBlockProps() }>
+			<PostChooserSidebar
+				postID={ selectedPostID }
+				postTitle={ selectedPostTitle }
+				postURL={ selectedPostURL }
+				onRemovePost={ calloutRemovePostHandler }
+				openButtonLabel={ 'Select Post Foo' }
+				changeButtonLabel={ 'Change Post Foo' }
+				panelTitle={ __( 'Pick something…' ) }
+				onOpenPostChooserModal={ () => setIsPostChooserModalOpen( true ) }
+			>
+			</PostChooserSidebar>
+
 			<div className="wp-block-plugin-slug-block-callout-postpicker--container">
+
 				{ ! selectedPostID && (
-					<p>Post picker block, no post selected.</p>
+					<>
+						<p>Post picker block, no post selected. <a href="#" onClick={ setIsPostChooserModalOpen }>Select Post</a></p>
+
+						{ isSelected && (
+							<Button
+								isPrimary
+								onClick={ () => setIsPostChooserModalOpen( true ) }
+							>
+								{ __( 'Select Post' ) }
+							</Button>
+						) }
+					</>
+
 				) }
-				{ ! selectedPostID && isSelected && (
+
+				{ isPostChooserModalOpen && (
 					<PostChooser
 						modalLabel={ __( 'Choose a post (postchooser block)' ) }
-						buttonLabel="Choose your post if you dare..."
 						searchPlaceholder={ __(
 							'Pick something… (postchooser block)'
 						) }
 						onSelectPost={ calloutSelectedPostHandler }
 						modalTitle={ __( 'Choose a post (postchooser block)' ) }
+						onClose={ () => setIsPostChooserModalOpen( false ) }
 					/>
-				) }
+				)}
 				<div className="wp-block-plugin-slug-block-callout-postpicker--image">
 					{ isResolvingMedia && <LoadingSpinner /> }
 					{ hasResolvedMedia && media && (
@@ -186,21 +218,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					</div>
 				) }
 			</div>
-			<InspectorControls>
-				<PostChooserSidebar
-					postTitle={ selectedPostTitle }
-					postID={ selectedPostID }
-					postURL={ selectedPostURL }
-					onRemovePost={ calloutRemovePostHandler }
-				>
-					<PostChooser
-						onSelectPost={ calloutSelectedPostHandler }
-						buttonLabel={
-							selectedPostID ? 'Change' : 'Select Post'
-						}
-					/>
-				</PostChooserSidebar>
-			</InspectorControls>
+
 		</div>
 	);
 }


### PR DESCRIPTION

<img width="300" height="254" alt="image" src="https://github.com/user-attachments/assets/ca7e95dc-01ed-4558-9363-20a2a921d20f" />


- Cleans up the Post Chooser Sidebar component styling and layout
  - Ensures the Panel Title and all buttons and text in the PostChooserSidebar component can be controlled by passing in props from the block calling the component. This way instead of "_Select Post_" you could say "_Select Profile_" for the button. Or the Panel title in the sidebar could be "_Featured Profile_" or "_Recent Project_".
- Changes how the Post Chooser Sidebar Component and the Post Chooser Modal component are shown/hidden from various buttons. 
- A bit of miscellaneous cleanup (removing unused imports, adding empty functions so we don't get errors on props called as functions if they are undefined)


### Why make this change? 
The earlier approach was modeled on how 10up did it in BU Prepress. The state was handled inside the Post Chooser component to open/close the modal. The issue with this is that the PostChooserSidebar component has a button to open the modal. But it can't access the state of the modal inside the PostChooser component.  The previous approach used the concept of nesting components. In your block you'd have to call the PostChooserSidebar but then also wrap that component around another instance of the PostChooser component. The PostChooser component would be passed as a child and rendered in the sidebar essentially. When triggered it would open up. This worked but it has some downsides: 

- The block can't access the state to control opening/closing the modal. So if in a future block you needed to trigger the modal from some other ui element you couldn't do it. The PostChooser itself provided a button to open/close the modal. So essentially the previous PostChooser component was a `<Button>` component that opened a modal. 
- You can't open the PostChooser from another button or trigger in the block
- The block doesn't "know" if the modal is open or not, so if you need to show/hide something in the block when the modal is open...you can't. 

We also want to add a Toolbar button component for opening the modal and adding/removing the selected post for situations where a sidebar isn't optimal. That would have been difficult to get that toolbar button to open the modal with the previous approach. 


### Further work: 
I kept this PR small, but I think the PostChooser component unnecessarily now provides an extra component layer we no longer need since the Button component was removed and now all it returns is `<PostChooserModal>` component. So we can probably unwrap that a bit. 

Add a Toolbar Button Control that also opens/closes the modal and has a button to "Remove" the selected post. Kind of like how the Image block works for adding/removing images in an Image block. 