### PR TITLE
Dakota/gut 175 post picker fix flicker when searching

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,91 @@
+# BU Block Imports Development Guide
+
+## Project Overview
+BU Block Imports is a library of standardized React components, hooks, and utilities for WordPress blocks. The library is designed to be imported into other WordPress themes or plugins for consistent UI elements and data handling patterns.
+
+## Key Architectural Principles
+
+### Component Structure
+- Components use PascalCase naming without BU namespace (e.g., `LoadingSpinner`)
+- Export using `.mjs` extension to properly support ES modules
+- Each component has its own directory with:
+  - `index.mjs`: Entry point that exports the component
+  - Component implementation files
+  - `README.md`: Documentation on usage
+  - `editor.scss`: Component styles
+
+Example: `/components/Pagination/index.mjs` exports the Pagination component
+
+### Hook Structure
+- Hooks use camelCase naming without BU namespace (e.g., `useRequestData`)
+- Export using `.mjs` extension
+- Each hook has its own directory with documentation
+
+Example: `/hooks/useRequestData/index.mjs` is used for fetching data from WordPress REST API
+
+### Export Pattern
+Components and hooks are selectively exported in the main `index.js` file. When implementing a new component or hook, add it there to make it available for consumers.
+
+## Development Workflow
+
+### Local Development
+```bash
+# Start development build with watch mode
+cd dev && npm run start
+
+# Start WordPress environment for testing
+cd dev && npm run env-start
+
+# Access WordPress CLI within environment
+cd dev && npm run env-wp
+```
+
+### Component Development
+1. Create new component in `/components/YourComponent/`
+2. Export from `/components/YourComponent/index.mjs`
+3. Add to main `index.js` exports
+4. Document with README.md
+
+### Testing
+Test components within the dev environment:
+1. Reference your component in a dev block in `/dev/src/blocks/`
+2. Build and test in the WordPress environment with `npm run env-start`
+
+## Key Integration Patterns
+
+### WordPress Data Integration
+- Use `useRequestData` hook for fetching from WordPress REST API
+- Use `useGetPagination` hook for pagination with WordPress data
+- Components should accept standard WordPress data structures as props
+
+Example from PostChooser:
+```javascript
+const [data, isLoading] = useRequestData('postType', selectedPostType, query);
+```
+
+### Component Communication
+- Props down, events up pattern
+- Use callback props for parent communication (e.g., `onChange`, `onSelectPost`)
+- Avoid global state management unless necessary
+
+## Publishing Process
+Publishing occurs automatically via GitHub Actions when creating a new release.
+The package is published to NPM with public access.
+
+## Common Patterns
+
+### Loading States
+Components handle their own loading states, typically with:
+1. Loading prop or state variable
+2. Conditional rendering based on loading state
+3. Optional LoadingSpinner component integration
+
+### Accessibility
+- Use WordPress components (Button, TextControl) that have built-in a11y
+- Provide proper ARIA attributes and labels
+- Support keyboard navigation
+
+### CSS Conventions
+- BEM-style class naming: `bu-components-[component]-[element]`
+- Use `editor.scss` for component-specific styles
+- Prefer inline styles for margins/padding via props

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1]
+
+- Added `useDebouncedInput` hook for handling debounced input fields
+- Fixed PostChooserModal search functionality to use proper debouncing
+- Fixed search field input lag by using immediate value for UI and debounced value for API calls
+- Improved performance for search functionality by reducing API calls
+
 ## [0.3.0]
 
 - Dev folder with wp-env and testing block plugin

--- a/components/PostChooser/editor-partials/modal/README.md
+++ b/components/PostChooser/editor-partials/modal/README.md
@@ -29,7 +29,8 @@ The `PostChooserModal` component serves as the main container for the post selec
 ## Internal State
 
 The component maintains several pieces of state:
-- `searchTerm` - Current search query
+- `searchTerm` - Current search query (updates immediately with user input)
+- `searchTermThrottled` - Debounced version of searchTerm (used for API calls)
 - `sortOrder` - Object with `orderby` and `order` properties
 - `searchType` - Type of search (recent, default, slug, ID)
 - `selectedPostType` - Currently selected post type
@@ -39,6 +40,14 @@ The component maintains several pieces of state:
 ## Pagination
 
 The component uses the `useGetPagination` hook to fetch pagination information and displays a `Pagination` component when there are multiple pages of results.
+
+## Debouncing Search Input
+
+The component uses the `useDebouncedInput` hook to manage input debouncing:
+1. `searchTerm` updates immediately to provide responsive user feedback in the search field
+2. `searchTermThrottled` only updates after a brief delay (500ms), reducing API calls while typing
+3. The search input uses the immediate `searchTerm` value for real-time UI updates
+4. All API requests and results display use the debounced `searchTermThrottled` value for better performance
 
 ## Internal Components
 

--- a/components/PostChooser/editor-partials/modal/README.md
+++ b/components/PostChooser/editor-partials/modal/README.md
@@ -45,7 +45,7 @@ The component uses the `useGetPagination` hook to fetch pagination information a
 
 The component uses the `useDebouncedInput` hook to manage input debouncing:
 1. `searchTerm` updates immediately to provide responsive user feedback in the search field
-2. `searchTermThrottled` only updates after a brief delay (500ms), reducing API calls while typing
+2. `searchTermThrottled` only updates after a brief delay (300ms), reducing API calls while typing
 3. The search input uses the immediate `searchTerm` value for real-time UI updates
 4. All API requests and results display use the debounced `searchTermThrottled` value for better performance
 

--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -2,7 +2,6 @@ import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 
-
 // Internal dependencies
 import { Results } from '../results/index.js';
 import { SearchUI } from '../search-ui/index.js';
@@ -13,6 +12,7 @@ import { LoadingOverlay, LoadingSpinner } from '../loading-overlay/index.js';
 import { Pagination } from '../../../../components/Pagination/index.mjs';
 import { useGetPagination } from '../../../../hooks/useGetPagination/index.mjs';
 import { useRequestData } from '../../../../hooks/useRequestData/index.mjs';
+import { useDebouncedInput } from '../../../../hooks/useDebouncedInput/index.mjs';
 
 // Import CSS
 import './editor.scss';
@@ -32,7 +32,11 @@ export const PostChooserModal = ( props ) => {
 		minCharacters = 3,
 	} = props;
 
-	const [ searchTerm, setSearchTerm ] = useState( '' );
+	// Use the new useDebouncedInput hook to handle both immediate and debounced search terms
+	// searchTerm - updates immediately with each keystroke for responsive UI
+	// debouncedSearchTerm - only updates after delay (used for API calls to reduce requests)
+	const [ searchTerm, setSearchTerm, searchTermThrottled ] = useDebouncedInput('', 300);
+
 	const [ sortOrder, setSortOrder ] = useState( {
 		orderby: 'date',
 		order: 'desc',
@@ -59,7 +63,7 @@ export const PostChooserModal = ( props ) => {
 	} );
 
 	// Determine if search term is numeric for ID search
-	const isSearchTermNumeric = searchTerm && !isNaN(searchTerm) && !isNaN(parseFloat(searchTerm));
+	const isSearchTermNumeric = searchTermThrottled && !isNaN(searchTermThrottled) && !isNaN(parseFloat(searchTermThrottled));
 
 	// Base query parameters
 	const baseQuery = {
@@ -78,23 +82,23 @@ export const PostChooserModal = ( props ) => {
 	};
 
 	// Content search query (only when there's a search term)
-	const contentQuery = searchTerm ? {
+	const contentQuery = searchTermThrottled ? {
 		...baseQuery,
-		search: searchTerm,
+		search: searchTermThrottled,
 		page: searchCurrentPage.default,
 	} : null;
 
 	// Slug search query (only when there's a search term) - exact slug match only
-	const slugQuery = searchTerm ? {
+	const slugQuery = searchTermThrottled ? {
 		...baseQuery,
-		slug: searchTerm,
+		slug: searchTermThrottled,
 		page: searchCurrentPage.slug,
 	} : null;
 
 	// ID search query (only when search term is numeric)
 	const idQuery = isSearchTermNumeric ? {
 		...baseQuery,
-		include: [parseInt(searchTerm)],
+		include: [parseInt(searchTermThrottled)],
 		page: searchCurrentPage.id,
 	} : null;
 
@@ -161,7 +165,7 @@ export const PostChooserModal = ( props ) => {
 	}, [recentPosts, recentPagination]);
 
 	useEffect(() => {
-		if (searchTerm) {
+		if (searchTermThrottled) {
 			setSearchResults(prevResults => ({
 				...prevResults,
 				default: {
@@ -176,10 +180,10 @@ export const PostChooserModal = ( props ) => {
 				default: { posts: null, totalItems: 0, totalPages: 0 }
 			}));
 		}
-	}, [contentPosts, contentPagination, searchTerm]);
+	}, [contentPosts, contentPagination, searchTermThrottled]);
 
 	useEffect(() => {
-		if (searchTerm) {
+		if (searchTermThrottled) {
 			setSearchResults(prevResults => ({
 				...prevResults,
 				slug: {
@@ -194,7 +198,7 @@ export const PostChooserModal = ( props ) => {
 				slug: { posts: null, totalItems: 0, totalPages: 0 }
 			}));
 		}
-	}, [slugPosts, slugPagination, searchTerm]);
+	}, [slugPosts, slugPagination, searchTermThrottled]);
 
 	useEffect(() => {
 		if (isSearchTermNumeric) {
@@ -259,14 +263,14 @@ export const PostChooserModal = ( props ) => {
 	const handleSearch = useCallback( () => {
 		// Trigger search by invalidating all search results
 		recentInvalidateResolver();
-		if (searchTerm) {
+		if (searchTermThrottled) {
 			contentInvalidateResolver();
 			slugInvalidateResolver();
 		}
 		if (isSearchTermNumeric) {
 			idInvalidateResolver();
 		}
-	}, [ recentInvalidateResolver, contentInvalidateResolver, slugInvalidateResolver, idInvalidateResolver, searchTerm, isSearchTermNumeric ] );
+	}, [ recentInvalidateResolver, contentInvalidateResolver, slugInvalidateResolver, idInvalidateResolver, searchTermThrottled, isSearchTermNumeric ] );
 
 	// Handle page change for current search type
 	const handlePageChange = (newPage) => {
@@ -285,14 +289,14 @@ export const PostChooserModal = ( props ) => {
 	* Doing so will cause a rerender and the setting will be undone.
 	*/
 	useEffect( () => {
-		if (searchTerm && searchType === 'recent') {
+		if (searchTermThrottled && searchType === 'recent') {
 			// Auto-switch to content search when user starts typing
 			setSearchType('default');
-		} else if (!searchTerm && searchType !== 'recent') {
+		} else if (!searchTermThrottled && searchType !== 'recent') {
 			// Auto-switch back to recent when search term is cleared
 			setSearchType('recent');
 		}
-	}, [ searchTerm ] );
+	}, [ searchTermThrottled ] );
 
 	// Get current results and metadata
 	const currentResults = getCurrentResults();
@@ -322,7 +326,7 @@ export const PostChooserModal = ( props ) => {
 					setSelectedPostType={ setSelectedPostType }
 				/>
 				<ResultsControls
-					searchTerm={ searchTerm }
+					searchTerm={ searchTermThrottled }
 					searchType={ searchType }
 					sortOrder={ sortOrder }
 					setSortOrder={ setSortOrder }
@@ -342,7 +346,7 @@ export const PostChooserModal = ( props ) => {
 							onSelectPost={ onSelectPost }
 							totalItems={ currentResults.totalItems }
 							loading={ currentLoading }
-							searchTerm={ searchTerm }
+							searchTerm={ searchTermThrottled }
 							searchType={ searchType }
 						/>
 						{ currentTotalPages > 1 && currentResults.posts && (

--- a/hooks/useDebouncedInput/README.md
+++ b/hooks/useDebouncedInput/README.md
@@ -1,0 +1,69 @@
+# useDebouncedInput Hook
+
+A hook for debouncing input field values.
+
+Note:
+This hook is recreated from the version in `@wordpress/compose` package in WordPress 6.6 and newer:
+https://github.com/WordPress/gutenberg/blob/wp/6.6/packages/compose/src/hooks/use-debounced-input/index.ts
+
+Once this Repo supports WP 6.6 this hook could be deprecated and instead use the core hook.
+
+## Description
+
+The `useDebouncedInput` hook is designed for handling input fields that need debounced values. It manages both the immediate input value (for UI responsiveness) and a debounced version that only updates after a specified delay (for operations like API requests).
+
+This hook is particularly useful for search fields, filter inputs, or any scenario where you want to reduce the frequency of operations triggered by input changes.
+
+## Usage
+
+```jsx
+import { useDebouncedInput } from 'block-imports/hooks/useDebouncedInput';
+
+function SearchComponent() {
+  // Returns three values:
+  // - searchTerm (immediate value that updates on every keystroke)
+  // - setSearchTerm (function to update the search term)
+  // - debouncedSearchTerm (value that updates after the specified delay)
+  const [searchTerm, setSearchTerm, debouncedSearchTerm] = useDebouncedInput('', 500);
+
+  // Use debouncedSearchTerm for API calls or expensive operations
+  useEffect(() => {
+    if (debouncedSearchTerm.length >= 3) {
+      performSearch(debouncedSearchTerm);
+    }
+  }, [debouncedSearchTerm]);
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        placeholder="Search..."
+      />
+      <p>Current input: {searchTerm}</p>
+      <p>Debounced input: {debouncedSearchTerm}</p>
+    </div>
+  );
+}
+```
+
+## Parameters
+
+| Parameter     | Type   | Description                                     | Default  |
+|--------------|--------|-------------------------------------------------|----------|
+| defaultValue | string | The initial value for the input                  | `''`     |
+| delay        | number | The debounce delay in milliseconds               | `500`    |
+
+## Return Value
+
+Array containing three elements:
+
+1. `input` (string): The current input value that updates immediately
+2. `setInput` (function): Function to update the input value
+3. `debouncedInput` (string): The debounced value that updates after the delay
+
+## Dependencies
+
+- `@wordpress/element`: For React hooks (`useState`, `useEffect`)
+- `@wordpress/compose`: For the `useDebounce` hook

--- a/hooks/useDebouncedInput/index.mjs
+++ b/hooks/useDebouncedInput/index.mjs
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+
+/**
+ * Hook for debouncing input field values.
+ *
+ * Returns an array with:
+ * - The current input value (updates immediately)
+ * - Function to update the input value
+ * - The debounced input value (updates after delay)
+ *
+ * @param {string} defaultValue - The default value for the input.
+ * @param {number} delay - The debounce delay in milliseconds.
+ * @return {[string, (value: string) => void, string]} Input values and setter.
+ */
+export function useDebouncedInput(defaultValue = '', delay = 500) {
+	const [input, setInput] = useState(defaultValue);
+	const [debouncedInput, setDebouncedInput] = useState(defaultValue);
+
+	// Create a debounced version of setDebouncedInput
+	const setDebouncedInputWithDelay = useDebounce(setDebouncedInput, delay);
+
+	// Effect to update the debounced value when input changes
+	useEffect(() => {
+		setDebouncedInputWithDelay(input);
+	}, [input, setDebouncedInputWithDelay]);
+
+	return [input, setInput, debouncedInput];
+}

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ export { useMedia } from './hooks/useMedia/index.mjs';
 // export { useRenderAppenderWithBlockLimit } from './hooks/useRenderAppenderWithBlockLimit';
 export { useRequestData } from './hooks/useRequestData/index.mjs';
 export { useGetPagination } from './hooks/useGetPagination/index.mjs';
+export { useDebouncedInput } from './hooks/useDebouncedInput/index.mjs';
 
 // Utils
 // A utility function is a standard JavaScript function that performs a specific task and is not tied to any particular framework or library. Utility functions are often used for tasks like data formatting, calculations, or other operations that don't require access to React's state or lifecycle. They can be called from anywhere in your code, including within React components or hooks.


### PR DESCRIPTION
This PR fixes the flickering issue with the earlier code. Our search was executing immediately on every keystroke and as fast as possible. This results in the search restarting over and over very quickly as the user types out their query. @tspears1 suggested using a throttling hook to eliminate this and only call the search queries after XX milliseconds. 

@tspears1 suggested the popular https://usehooks.com/usethrottle hook and it looks good however I'd prefer to avoid 3rd party dependencies as this Post Chooser will be compiled into blocks and the less dependencies the better for now IMO. 

## Current flickering issue: 

https://github.com/user-attachments/assets/c8f3e5ec-41c3-4b57-a786-30d78cdf4efe




I looked and WordPress has a `useThrottle()` hook in WP 5.8 in the @wordpress/compose package. However when testing it  this only works for functions, not throttling state values like `searchTerm`. 

Copilot suggested creating a custom throttling function in the Modal JS file using useState and a setTimeout but I didn't like this adding more complexity to the modal code. Some further research in the WP codebase led me to find `useDebouncedInput()` hook https://github.com/WordPress/gutenberg/blob/wp/6.6/packages/compose/src/hooks/use-debounced-input/index.ts. 

Unfortunately this hook is only available in WP 6.6. However with the help of CoPilot I was able to replicate it as a new custom hook in Block Imports since the hooks that `useDebouncedInput()` uses are available in WP 5.8 such as `useDebounce()`.  Our hook is slightly better actually as it let's us pass in a value in ms to delay. But when we upgrade to 6.6 we could switch over to that and deprecate this hook. 


The result is this lovely example with no flickering: 

## Flickering removed
https://github.com/user-attachments/assets/9773e21e-4150-4bdb-b1ca-78530cd3f744

