### PR TITLE
Dakota/gut 175 post picker fix pagination change search query bug

### DIFF
--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -285,7 +285,7 @@ export const PostChooserModal = ( props ) => {
 	* When the search term changes or when we have search results,
 	* automatically switch to the appropriate search type.
 	*
-	* When the search Term changes, set the search current page to 1.
+	* When the search Term changes, set ALL search current pages to 1.
 	* If not, the query in useSelect() may throw an error if we request
 	* a page number that doesn't exist. Anytime the searchTerm changes this
 	* should be set back to page 1 of the results as the old results are
@@ -295,11 +295,15 @@ export const PostChooserModal = ( props ) => {
 	* Doing so will cause a rerender and the setting will be undone.
 	*/
 	useEffect( () => {
-		if ( searchTerm ) {
-			// If searchTerm changed, set the current page for this search type to 1.
+		if ( searchTermThrottled !== undefined ) {
+			// When searchTerm changes (throttled), reset search pages to 1 for types that use the search term
+			// Keep the "recent" page as is since it doesn't depend on searchTerm
+			// This prevents "invalid page" errors when changing search terms after pagination
 			setSearchCurrentPage(prev => ({
 				...prev,
-				[searchType]: 1
+				default: 1,
+				slug: 1,
+				id: 1
 			}));
 		}
 

--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -295,17 +295,16 @@ export const PostChooserModal = ( props ) => {
 	* Doing so will cause a rerender and the setting will be undone.
 	*/
 	useEffect( () => {
-		if ( searchTermThrottled !== undefined ) {
-			// When searchTerm changes (throttled), reset search pages to 1 for types that use the search term
-			// Keep the "recent" page as is since it doesn't depend on searchTerm
-			// This prevents "invalid page" errors when changing search terms after pagination
-			setSearchCurrentPage(prev => ({
-				...prev,
-				default: 1,
-				slug: 1,
-				id: 1
-			}));
-		}
+		// When searchTermThrottled changes (due to dependency array),
+		// reset search pages to 1 for types that use the search term
+		// Keep the "recent" page as is since it doesn't depend on searchTerm
+		// This prevents "invalid page" errors when changing search terms after pagination
+		setSearchCurrentPage(prev => ({
+			...prev,
+			default: 1,
+			slug: 1,
+			id: 1
+		}));
 
 		if (searchTermThrottled && searchType === 'recent') {
 			// Auto-switch to content search when user starts typing

--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -154,68 +154,75 @@ export const PostChooserModal = ( props ) => {
 
 	// Update search results state when individual search results change
 	useEffect(() => {
+		// Update the recent posts search results with the latest data and pagination
+		const recentSearchResult = {
+			posts: recentPosts,
+			totalItems: recentPagination.totalItems || 0,
+			totalPages: recentPagination.totalPages || 0,
+		};
+
 		setSearchResults(prevResults => ({
 			...prevResults,
-			recent: {
-				posts: recentPosts,
-				totalItems: recentPagination.totalItems || 0,
-				totalPages: recentPagination.totalPages || 0,
-			}
+			recent: recentSearchResult
 		}));
 	}, [recentPosts, recentPagination]);
 
 	useEffect(() => {
-		if (searchTermThrottled) {
-			setSearchResults(prevResults => ({
-				...prevResults,
-				default: {
-					posts: contentPosts,
-					totalItems: contentPagination.totalItems || 0,
-					totalPages: contentPagination.totalPages || 0,
-				}
-			}));
-		} else {
-			setSearchResults(prevResults => ({
-				...prevResults,
-				default: { posts: null, totalItems: 0, totalPages: 0 }
-			}));
-		}
+		// Determine the appropriate search result object based on whether we have a search term
+		// If searchTermThrottled exists: use the API data with pagination information
+		// If no search term: reset to empty/null values to clear results
+		const defaultSearchResult = searchTermThrottled 
+			? {
+				posts: contentPosts,
+				totalItems: contentPagination.totalItems || 0,
+				totalPages: contentPagination.totalPages || 0,
+			}
+			: { posts: null, totalItems: 0, totalPages: 0 };
+		
+		// Update just the "default" search type in our results state object,
+		// preserving other search type results
+		setSearchResults(prevResults => ({
+			...prevResults,
+			default: defaultSearchResult
+		}));
 	}, [contentPosts, contentPagination, searchTermThrottled]);
 
 	useEffect(() => {
-		if (searchTermThrottled) {
-			setSearchResults(prevResults => ({
-				...prevResults,
-				slug: {
-					posts: slugPosts,
-					totalItems: slugPagination.totalItems || 0,
-					totalPages: slugPagination.totalPages || 0,
-				}
-			}));
-		} else {
-			setSearchResults(prevResults => ({
-				...prevResults,
-				slug: { posts: null, totalItems: 0, totalPages: 0 }
-			}));
-		}
+		// Determine slug search results based on search term presence
+		// If searchTermThrottled exists: use the slug search results and pagination
+		// If no search term: reset to empty/null values
+		const slugSearchResult = searchTermThrottled 
+			? {
+				posts: slugPosts,
+				totalItems: slugPagination.totalItems || 0,
+				totalPages: slugPagination.totalPages || 0,
+			}
+			: { posts: null, totalItems: 0, totalPages: 0 };
+		
+		// Update the slug search results while preserving other search types
+		setSearchResults(prevResults => ({
+			...prevResults,
+			slug: slugSearchResult
+		}));
 	}, [slugPosts, slugPagination, searchTermThrottled]);
 
 	useEffect(() => {
-		if (isSearchTermNumeric) {
-			setSearchResults(prevResults => ({
-				...prevResults,
-				id: {
-					posts: idPosts,
-					totalItems: idPagination.totalItems || 0,
-					totalPages: idPagination.totalPages || 0,
-				}
-			}));
-		} else {
-			setSearchResults(prevResults => ({
-				...prevResults,
-				id: { posts: null, totalItems: 0, totalPages: 0 }
-			}));
-		}
+		// Determine ID search results based on whether search term is numeric
+		// If isSearchTermNumeric is true: use the ID search results and pagination
+		// If not numeric: reset to empty/null values
+		const idSearchResult = isSearchTermNumeric 
+			? {
+				posts: idPosts,
+				totalItems: idPagination.totalItems || 0,
+				totalPages: idPagination.totalPages || 0,
+			}
+			: { posts: null, totalItems: 0, totalPages: 0 };
+		
+		// Update the ID search results while preserving other search types
+		setSearchResults(prevResults => ({
+			...prevResults,
+			id: idSearchResult
+		}));
 	}, [idPosts, idPagination, isSearchTermNumeric]);
 
 	// Get current results based on selected search type

--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -281,10 +281,24 @@ export const PostChooserModal = ( props ) => {
 	* When the search term changes or when we have search results,
 	* automatically switch to the appropriate search type.
 	*
+	* When the search Term changes, set the search current page to 1.
+	* If not, the query in useSelect() may throw an error if we request
+	* a page number that doesn't exist. Anytime the searchTerm changes this
+	* should be set back to page 1 of the results as the old results are
+	* now invalid.
+	*
 	* Note: Don't enter `searchType` as a dependency in this effect.
 	* Doing so will cause a rerender and the setting will be undone.
 	*/
 	useEffect( () => {
+		if ( searchTerm ) {
+			// If searchTerm changed, set the current page for this search type to 1.
+			setSearchCurrentPage(prev => ({
+				...prev,
+				[searchType]: 1
+			}));
+		}
+
 		if (searchTerm && searchType === 'recent') {
 			// Auto-switch to content search when user starts typing
 			setSearchType('default');


### PR DESCRIPTION
# Fix: Post Chooser Pagination Bug - Issue #28

This PR fixes an issue where changing the search query after navigating to page 2 or higher of search results could cause an error.

## Problem
When a user performs a search with multiple pages of results, navigates to a higher page, and then modifies their search query (resulting in fewer pages), the component would still try to load the previously selected page number. This caused a REST API error when the requested page number exceeded the available pages in the new search results.

## Solution
The fix modifies the search term change handler to reset pagination to page 1 for all search types that depend on the search term (default, slug, and id), while preserving the current page for the "recent" search type which doesn't depend on the search term.

This prevents the "rest_post_invalid_page_number" error and ensures a consistent user experience when refining search queries.

## Testing
1. Search for a term that produces multiple pages of results
2. Navigate to page 2 or higher
3. Change the search query to something more specific (with fewer results)
4. Verify that the search works correctly without errors

Fixes #28
