### PR TITLE
Change useRequestData & useGetPagination parameter names & minor bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- useRequestData & useGetPagination
+  - Fixed parameter names in `useRequestData` and `useGetPagination` hooks to match WordPress core `getEntityRecords` function parameters (`kind`, `name`, `query`)
+  - Fixed bug in `useGetPagination` where `getEntitiesByKind()` was incorrectly using the wrong parameter
+  - Updated documentation to reflect consistent parameter naming across hooks
+- PostChooser Component
+  - Fixed pagination error that could occur when quickly clicking between pages by resetting current page to `1` faster with useEffect tied to `searchTerm`
+  - Fixed an issue with null values being passed to REST API endpoints by switching the useRequestData calls to use `undefined` when the query isn't ready/set/etc. The console was showing calls to `some-endpoint/null` and throwing a 404 or error. `undefined` seems to be better.
+
 ## [0.3.1]
 
 - Added `useDebouncedInput` hook for handling debounced input fields

--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -291,17 +291,30 @@ export const PostChooserModal = ( props ) => {
 	* When the search term changes or when we have search results,
 	* automatically switch to the appropriate search type.
 	*
+	* Note: Don't enter `searchType` as a dependency in this effect.
+	* Doing so will cause a rerender and the setting will be undone.
+	*/
+	useEffect( () => {
+		if (searchTermThrottled && searchType === 'recent') {
+			// Auto-switch to content search when user starts typing
+			setSearchType('default');
+		} else if (!searchTermThrottled && searchType !== 'recent') {
+			// Auto-switch back to recent when search term is cleared
+			setSearchType('recent');
+		}
+	}, [ searchTermThrottled ] );
+
+	/**
 	* When the search Term changes, set ALL search current pages to 1.
 	* If not, the query in useSelect() may throw an error if we request
 	* a page number that doesn't exist. Anytime the searchTerm changes this
 	* should be set back to page 1 of the results as the old results are
 	* now invalid.
-	*
-	* Note: Don't enter `searchType` as a dependency in this effect.
-	* Doing so will cause a rerender and the setting will be undone.
+	* Setting this to run on searchTermThrottled was too slow at times due
+	* to the delay in the Throttler.
 	*/
 	useEffect( () => {
-		// When searchTermThrottled changes (due to dependency array),
+		// When searchTerm changes (due to dependency array),
 		// reset search pages to 1 for types that use the search term
 		// Keep the "recent" page as is since it doesn't depend on searchTerm
 		// This prevents "invalid page" errors when changing search terms after pagination
@@ -312,14 +325,8 @@ export const PostChooserModal = ( props ) => {
 			id: 1
 		}));
 
-		if (searchTermThrottled && searchType === 'recent') {
-			// Auto-switch to content search when user starts typing
-			setSearchType('default');
-		} else if (!searchTermThrottled && searchType !== 'recent') {
-			// Auto-switch back to recent when search term is cleared
-			setSearchType('recent');
-		}
-	}, [ searchTermThrottled ] );
+	}, [ searchTerm ] );
+
 
 	// Get current results and metadata
 	const currentResults = getCurrentResults();

--- a/components/PostChooser/editor-partials/modal/index.js
+++ b/components/PostChooser/editor-partials/modal/index.js
@@ -85,21 +85,21 @@ export const PostChooserModal = ( props ) => {
 		...baseQuery,
 		search: searchTermThrottled,
 		page: searchCurrentPage.default,
-	} : null;
+	} : undefined;
 
 	// Slug search query (only when there's a search term) - exact slug match only
 	const slugQuery = searchTermThrottled ? {
 		...baseQuery,
 		slug: searchTermThrottled,
 		page: searchCurrentPage.slug,
-	} : null;
+	} : undefined;
 
 	// ID search query (only when search term is numeric)
 	const idQuery = isSearchTermNumeric ? {
 		...baseQuery,
 		include: [parseInt(searchTermThrottled)],
 		page: searchCurrentPage.id,
-	} : null;
+	} : undefined;
 
 	// Use separate useRequestData hooks for each search type
 	const [recentPosts, recentLoading, recentInvalidateResolver] = useRequestData(

--- a/hooks/useGetPagination/README.md
+++ b/hooks/useGetPagination/README.md
@@ -31,8 +31,8 @@ const { totalItems, totalPages } = pagination;
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `entity` | string | `'postType'` | The entity type to fetch (e.g., 'postType', 'taxonomy') |
-| `kind` | string | `'post'` | The entity kind (e.g., 'post', 'page', 'category') |
+| `kind` | string | `'postType'` | The entity kind to fetch (e.g., 'postType', 'taxonomy') |
+| `name` | string | `'post'` | The entity name (e.g., 'post', 'page', 'category') |
 | `query` | object | `{}` | Query parameters to filter results |
 
 ## Return Value

--- a/hooks/useGetPagination/index.mjs
+++ b/hooks/useGetPagination/index.mjs
@@ -20,12 +20,12 @@ if ( ! hasNewSelectors) {
 /**
  * Hook for retrieving data from the WordPress REST API.
  *
- * @param {string} entity           The entity to retrieve. Defaults to postType.
- * @param {string} kind             The entity kind to retrieve. Defaults to post.
+ * @param {string} kind           The entity kind to retrieve. Defaults to postType.
+ * @param {string} name           The entity name to retrieve. Defaults to post.
  * @param {object | number} [query] Optional. Query to pass to the getEntityRecords request. Defaults to an empty object. If a number is passed, it is used as the ID of the entity to retrieve via getEntityRecord.
  * @returns {Object}                An object containing pagination information: { pagination: { totalItems: number, totalPages: number, perPage: number } }
  */
-export const useGetPagination = (entity = 'postType', kind = 'post', query = {} ) => {
+export const useGetPagination = (kind = 'postType', name = 'post', query = {} ) => {
 	// Memoize the query object to ensure stable reference
 	const memoizedQuery = useMemo(() => query, [JSON.stringify(query)]);
 
@@ -54,18 +54,18 @@ export const useGetPagination = (entity = 'postType', kind = 'post', query = {} 
 			const coreSelect = select(coreStore);
 
 			return {
-				totalItems: hasNewSelectors ? coreSelect.getEntityRecordsTotalItems(entity, kind, query) : 0,
-				totalPages: hasNewSelectors ? coreSelect.getEntityRecordsTotalPages(entity, kind, query) : 0,
+				totalItems: hasNewSelectors ? coreSelect.getEntityRecordsTotalItems(kind, name, query) : 0,
+				totalPages: hasNewSelectors ? coreSelect.getEntityRecordsTotalPages(kind, name, query) : 0,
 				isLoading: hasNewSelectors ? select('core/data').isResolving(
 					coreStore,
 					'getEntityRecords', [
-						entity,
 						kind,
+						name,
 						query,
 					]) : false, // Return false if the new selectors are not available.
 			};
 		},
-		[entity, kind, query, hasNewSelectors],
+		[kind, name, query, hasNewSelectors],
 	);
 
 	/**
@@ -91,17 +91,17 @@ export const useGetPagination = (entity = 'postType', kind = 'post', query = {} 
 	 * This allows us to construct the API endpoint for fetching pagination information via apiFetch.
 	 *
 	 * @effect
-	 * @dependency {string} entity
-	 * @dependency {string} kind
+	 * @dependency {string} kind	The entity kind.
+	 * @dependency {string} name 	The entity name.
 	 * @returns {Object} The entity configuration object, or undefined if not found.
 	 */
 	const entityConfig = useSelect(
 		(select) => {
 			// Use getEntitiesByKind to get the entity config.
-			const entities = select(coreStore).getEntitiesByKind(entity);
-			return entities?.find( e => e.name === kind );
+			const entities = select(coreStore).getEntitiesByKind(name);
+			return entities?.find( e => e.name === name );
 		},
-		[entity, kind]
+		[kind, name]
 	);
 
 	/**

--- a/hooks/useGetPagination/index.mjs
+++ b/hooks/useGetPagination/index.mjs
@@ -18,11 +18,11 @@ if ( ! hasNewSelectors) {
 
 
 /**
- * Hook for retrieving data from the WordPress REST API.
+ * Hook for retrieving pagination information from the WordPress REST API.
  *
  * @param {string} kind           The entity kind to retrieve. Defaults to postType.
  * @param {string} name           The entity name to retrieve. Defaults to post.
- * @param {object | number} [query] Optional. Query to pass to the getEntityRecords request. Defaults to an empty object. If a number is passed, it is used as the ID of the entity to retrieve via getEntityRecord.
+ * @param {object | number} [query] Optional. Query to pass to the getEntityRecords request. Defaults to an empty object.
  * @returns {Object}                An object containing pagination information: { pagination: { totalItems: number, totalPages: number, perPage: number } }
  */
 export const useGetPagination = (kind = 'postType', name = 'post', query = {} ) => {
@@ -98,7 +98,7 @@ export const useGetPagination = (kind = 'postType', name = 'post', query = {} ) 
 	const entityConfig = useSelect(
 		(select) => {
 			// Use getEntitiesByKind to get the entity config.
-			const entities = select(coreStore).getEntitiesByKind(name);
+			const entities = select(coreStore).getEntitiesByKind(kind);
 			return entities?.find( e => e.name === name );
 		},
 		[kind, name]
@@ -184,7 +184,7 @@ export const useGetPagination = (kind = 'postType', name = 'post', query = {} ) 
 		loadPaginationData();
 
 
-	}, [memoizedQuery, entityConfig]);
+	}, [memoizedQuery, entityConfig ]);
 
 
 

--- a/hooks/useRequestData/README.md
+++ b/hooks/useRequestData/README.md
@@ -4,6 +4,26 @@
 
 `useRequestData` is a basically a wrapper around `getEntityRecords` (`getEntityRecord` if the query is not an array), with addtional processing that would be standard practice. This reduces the amount of redundant code within a theme.
 
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `kind` | string | `'postType'` | The entity kind to fetch (e.g., 'postType', 'taxonomy') |
+| `name` | string | `'post'` | The entity name (e.g., 'post', 'page', 'category') |
+| `query` | object or number | `{}` | Query parameters for filtering results or a specific ID for single entity retrieval |
+
+## Return Value
+
+The hook returns an array with the following elements:
+
+```js
+[
+  data,             // The fetched data (array or single entity object)
+  isLoading,        // Boolean indicating if the request is in progress
+  invalidateResolver // Function to invalidate the resolver and refresh the data
+]
+```
+
 ## Examples
 
 There are a number of examples within the `dev\src\blocks` folder, highliting the flexibility of `useRequestData`:

--- a/hooks/useRequestData/index.mjs
+++ b/hooks/useRequestData/index.mjs
@@ -13,30 +13,30 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Hook for retrieving data from the WordPress REST API.
  *
- * @param {string} entity           The entity to retrieve. Defaults to postType.
- * @param {string} kind             The entity kind to retrieve. Defaults to posts.
+ * @param {string} kind           The entity kind to retrieve. Defaults to postType.
+ * @param {string} name           The entity name to retrieve. Defaults to posts.
  * @param {object | number} [query] Optional. Query to pass to the geEntityRecords request. Defaults to an empty object. If a number is passed, it is used as the ID of the entity to retrieve via getEntityRecord.
  * @returns {Array} The data returned from the request.
  */
-export const useRequestData = (entity='postType', kind='post', query = {} ) => {
+export const useRequestData = (kind='postType', name='post', query = {} ) => {
 	const whichGER = isObject(query) ? 'getEntityRecords' : 'getEntityRecord';
 	const { invalidateResolution } = useDispatch('core/data');
 	const { data, isLoading } = useSelect(
 		(select) => {
 			return {
-				data: select(coreStore)[whichGER](entity, kind, query),
+				data: select(coreStore)[whichGER](kind, name, query),
 				isLoading: select('core/data').isResolving(coreStore, whichGER, [
-					entity,
 					kind,
+					name,
 					query,
 				]),
 			};
 		},
-		[entity, kind, query],
+		[kind, name, query],
 	);
 
 	const invalidateResolver = () => {
-		invalidateResolution(coreStore, whichGER, [entity, kind, query]);
+		invalidateResolution(coreStore, whichGER, [kind, name, query]);
 	};
 
 	return [data, isLoading, invalidateResolver];


### PR DESCRIPTION
# Fix useRequestData and useGetPagination Parameter Names

## Overview
This PR adjusts the parameter names in our custom hooks to align with WordPress core function parameter naming conventions. The changes ensure consistency between our API and the WordPress core-data module's getEntityRecords function, making the codebase more maintainable and easier to understand.

## Changes
1. Updated parameter naming in `useRequestData` and `useGetPagination` hooks to use the standard WordPress parameter order:
   - `kind` (first parameter): The entity kind (e.g., 'postType', 'taxonomy')
   - `name` (second parameter): The entity name (e.g., 'post', 'page')
   - `query` (third parameter): Query parameters object

2. Fixed a bug in `useGetPagination` where `getEntitiesByKind()` was incorrectly using the `name` parameter instead of `kind`

3. Updated README.md documentation for both hooks to reflect the correct parameter names and order

4. Post Chooser Component bug fixes:
  - Fixed pagination error that could occur when quickly clicking between pages by resetting current page to `1` faster with useEffect tied to `searchTerm`
  - Fixed an issue with null values being passed to REST API endpoints by switching the useRequestData calls to use `undefined` when the query isn't ready/set/etc. The console was showing calls to `some-endpoint/null` and throwing a 404 or error. `undefined` seems to be better.


## Testing
The hooks have been tested across multiple use cases in the PostChooser component, confirming that all data fetching and pagination functionality works as expected after these changes.
